### PR TITLE
feat: display bridge transactions

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@tari-project:registry=https://npm.pkg.github.com

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
                 "@reown/appkit-adapter-wagmi": "^1.7.4",
                 "@tanstack/react-query": "^5.77.2",
                 "@tari-project/tari-tower": "^0.0.42",
+                "@tari-project/wxtm-bridge-backend-api": "^0.1.20",
                 "@tauri-apps/api": "^2.4.0",
                 "@tauri-apps/plugin-clipboard-manager": "^2.2.2",
                 "@tauri-apps/plugin-os": "^2.2.1",
@@ -3019,6 +3020,12 @@
                 "min-signal": "^1.0.2",
                 "three": "^0.176.0"
             }
+        },
+        "node_modules/@tari-project/wxtm-bridge-backend-api": {
+            "version": "0.1.20",
+            "resolved": "https://npm.pkg.github.com/download/@tari-project/wxtm-bridge-backend-api/0.1.20/48e3b6ebeb8dc33cb9e3a10aa1bf81d669e1f18b",
+            "integrity": "sha512-GG/cpU5jRxPasd+yN/gurLH8S05WCM9ehc/VykqU82lVdNWKPqiCZ9r6fhkpORE+SlaXXs4j0dbfUwEAo2Iu3g==",
+            "license": "ISC"
         },
         "node_modules/@tauri-apps/api": {
             "version": "2.5.0",
@@ -6720,16 +6727,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"
-            }
-        },
-        "node_modules/encodeurl": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
-            "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.8"
             }
         },
         "node_modules/es-abstract": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
         "@reown/appkit-adapter-wagmi": "^1.7.4",
         "@tanstack/react-query": "^5.77.2",
         "@tari-project/tari-tower": "^0.0.42",
+        "@tari-project/wxtm-bridge-backend-api": "^0.1.20",
         "@tauri-apps/api": "^2.4.0",
         "@tauri-apps/plugin-clipboard-manager": "^2.2.2",
         "@tauri-apps/plugin-os": "^2.2.1",

--- a/src-tauri/src/app_in_memory_config.rs
+++ b/src-tauri/src/app_in_memory_config.rs
@@ -38,6 +38,11 @@ const AIRDROP_API_BASE_URL: &str = std::env!(
 const TELEMETRY_API_URL: &str =
     std::env!("TELEMETRY_API_URL", "TELEMETRY_API_URL env var not defined");
 
+const NEXT_PUBLIC_BACKEND_API_URL: &str = match option_env!("NEXT_PUBLIC_BACKEND_API_URL") {
+    Some(val) => val,
+    None => "NEXT_PUBLIC_BACKEND_API_URL env var not defined",
+};
+
 pub const DEFAULT_EXCHANGE_ID: &str = "universal";
 pub const EXCHANGE_ID: &str = match option_env!("EXCHANGE_ID") {
     Some(val) => val,
@@ -50,6 +55,7 @@ pub struct AppInMemoryConfig {
     pub airdrop_api_url: String,
     pub telemetry_api_url: String,
     pub exchange_id: String,
+    pub next_public_backend_api_url: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -58,6 +64,7 @@ pub struct AirdropInMemoryConfig {
     pub airdrop_url: String,
     pub airdrop_api_url: String,
     pub exchange_id: Option<String>,
+    pub next_public_backend_api_url: String,
 }
 
 impl From<AppInMemoryConfig> for AirdropInMemoryConfig {
@@ -66,6 +73,7 @@ impl From<AppInMemoryConfig> for AirdropInMemoryConfig {
             airdrop_url: app_config.airdrop_url,
             airdrop_api_url: app_config.airdrop_api_url,
             exchange_id: Some(app_config.exchange_id),
+            next_public_backend_api_url: app_config.next_public_backend_api_url,
         }
     }
 }
@@ -77,6 +85,7 @@ impl Default for AppInMemoryConfig {
             airdrop_api_url: "https://ut.tari.com".into(),
             telemetry_api_url: "https://ut.tari.com/push".into(),
             exchange_id: EXCHANGE_ID.into(),
+            next_public_backend_api_url: NEXT_PUBLIC_BACKEND_API_URL.into(),
         }
     }
 }
@@ -122,6 +131,7 @@ impl AppInMemoryConfig {
             airdrop_api_url: AIRDROP_API_BASE_URL.into(),
             telemetry_api_url: TELEMETRY_API_URL.into(),
             exchange_id: EXCHANGE_ID.into(),
+            next_public_backend_api_url: NEXT_PUBLIC_BACKEND_API_URL.into(),
         };
 
         #[cfg(all(feature = "airdrop-local", not(feature = "airdrop-env")))]
@@ -130,6 +140,7 @@ impl AppInMemoryConfig {
             airdrop_api_url: "http://localhost:3004".into(),
             telemetry_api_url: "http://localhost:3004".into(),
             exchange_id: EXCHANGE_ID.into(),
+            next_public_backend_api_url: NEXT_PUBLIC_BACKEND_API_URL.into(),
         };
 
         #[cfg(not(any(

--- a/src/components/transactions/components/StatusList/styles.ts
+++ b/src/components/transactions/components/StatusList/styles.ts
@@ -4,6 +4,7 @@ import { SendStatus } from '../../send/SendModal';
 export const Wrapper = styled('div')`
     display: flex;
     flex-direction: column;
+    width: 100%;
 `;
 
 export const Entry = styled.div`

--- a/src/components/transactions/history/BridgeHoveredItem.tsx
+++ b/src/components/transactions/history/BridgeHoveredItem.tsx
@@ -1,0 +1,19 @@
+import React, { memo } from 'react';
+
+import { ButtonWrapper, HoverWrapper } from './ListItem.styles.ts';
+
+interface Props {
+    button?: React.ReactNode;
+}
+
+const BridgeItemHover = memo(function BridgeItemHover({ button }: Props) {
+    return (
+        <HoverWrapper initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}>
+            <ButtonWrapper initial={{ opacity: 0, x: 5 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: 5 }}>
+                {button}
+            </ButtonWrapper>
+        </HoverWrapper>
+    );
+});
+
+export default BridgeItemHover;

--- a/src/components/transactions/history/BridgeListItem.tsx
+++ b/src/components/transactions/history/BridgeListItem.tsx
@@ -1,0 +1,109 @@
+import { memo, useRef, useState } from 'react';
+import { AnimatePresence } from 'motion/react';
+import { formatNumber, FormatPreset, truncateMiddle } from '@app/utils';
+import { BridgeBaseItemProps, BridgeHistoryListItemProps } from '../types.ts';
+import BridgeItemHover from './BridgeHoveredItem.tsx';
+import {
+    BlockInfoWrapper,
+    Chip,
+    Content,
+    ContentWrapper,
+    CurrencyText,
+    ItemWrapper,
+    TimeWrapper,
+    TitleWrapper,
+    ValueChangeWrapper,
+    ValueWrapper,
+} from './ListItem.styles.ts';
+import { useUIStore } from '@app/store';
+import { useTranslation } from 'react-i18next';
+import { Button } from '@app/components/elements/buttons/Button.tsx';
+import { formatTimeStamp, getTimestampFromTransaction } from './helpers.ts';
+
+const BaseItem = memo(function BaseItem({ title, time, value, chip, onClick }: BridgeBaseItemProps) {
+    // note re. isPositiveValue:
+    // amounts in the tx response are always positive numbers but
+    // if the transaction is Outbound, the value is negative
+
+    const displayTitle = title.length > 26 ? truncateMiddle(title, 8) : title;
+    return (
+        <ContentWrapper onClick={onClick}>
+            <Content>
+                <BlockInfoWrapper>
+                    <TitleWrapper title={title}>{displayTitle}</TitleWrapper>
+                    <TimeWrapper variant="p">{time}</TimeWrapper>
+                </BlockInfoWrapper>
+            </Content>
+            <Content>
+                {chip ? (
+                    <Chip>
+                        <span>{chip}</span>
+                    </Chip>
+                ) : null}
+
+                <ValueWrapper>
+                    <ValueChangeWrapper $isPositiveValue={false}>{`-`}</ValueChangeWrapper>
+                    {value}
+                    <CurrencyText>{`XTM`}</CurrencyText>
+                </ValueWrapper>
+            </Content>
+        </ContentWrapper>
+    );
+});
+
+const BridgeHistoryListItem = memo(function ListItem({
+    item,
+    index,
+    itemIsNew = false,
+    setDetailsItem,
+}: BridgeHistoryListItemProps) {
+    const { t } = useTranslation('wallet');
+    const hideWalletBalance = useUIStore((s) => s.hideWalletBalance);
+
+    const ref = useRef<HTMLDivElement>(null);
+
+    const [hovering, setHovering] = useState(false);
+
+    const earningsFormatted = hideWalletBalance
+        ? `***`
+        : formatNumber(Number(item.tokenAmount), FormatPreset.XTM_COMPACT).toLowerCase();
+    const time = formatTimeStamp(getTimestampFromTransaction(item));
+
+    const baseItem = (
+        <BaseItem
+            title={'Bridge XTM to WXTM'}
+            time={time}
+            value={earningsFormatted}
+            status={item?.status}
+            chip={itemIsNew ? t('new') : ''}
+        />
+    );
+
+    const detailsButton = (
+        <Button
+            size="smaller"
+            variant="outlined"
+            onClick={(e) => {
+                e.stopPropagation();
+                setDetailsItem?.({ ...item, createdAt: time });
+            }}
+        >
+            {t(`history.view-details`)}
+        </Button>
+    );
+
+    return (
+        <ItemWrapper
+            ref={ref}
+            data-index={index}
+            style={{ height: 48 }}
+            onMouseEnter={() => setHovering(true)}
+            onMouseLeave={() => setHovering(false)}
+        >
+            <AnimatePresence>{hovering && <BridgeItemHover button={detailsButton} />}</AnimatePresence>
+            {baseItem}
+        </ItemWrapper>
+    );
+});
+
+export { BridgeHistoryListItem };

--- a/src/components/transactions/history/HistoryList.tsx
+++ b/src/components/transactions/history/HistoryList.tsx
@@ -12,6 +12,7 @@ import ListLoadingAnimation from '@app/containers/navigation/components/Wallet/L
 import { PlaceholderItem } from './ListItem.styles.ts';
 import { LoadingText } from '@app/containers/navigation/components/Wallet/ListLoadingAnimation/styles.ts';
 import { TransactionDetails } from '@app/components/transactions/history/details/TransactionDetails.tsx';
+import { convertBridgeTransactionsToTransactions } from '@app/utils/getTxStatus.ts';
 
 const HistoryList = memo(function HistoryList() {
     const { t } = useTranslation('wallet');
@@ -21,11 +22,17 @@ const HistoryList = memo(function HistoryList() {
     const walletScanning = useWalletStore((s) => s.wallet_scanning);
     const hasMore = useWalletStore((s) => s.has_more_transactions);
     const transactions = useWalletStore((s) => s.transactions);
+    const bridgeTransactions = useWalletStore((s) => s.bridge_transactions);
 
     const [detailsItem, setDetailsItem] = useState<TransactionInfo | null>(null);
 
     const combinedTransactions = useMemo(
-        () => [...pendingTransactions, ...transactions] as TransactionInfo[],
+        () =>
+            [
+                ...pendingTransactions,
+                ...transactions,
+                // ...convertBridgeTransactionsToTransactions(bridgeTransactions),
+            ] as TransactionInfo[],
         [pendingTransactions, transactions]
     );
 

--- a/src/components/transactions/history/details/TransactionDetails.tsx
+++ b/src/components/transactions/history/details/TransactionDetails.tsx
@@ -8,9 +8,10 @@ import { Wrapper } from './styles.ts';
 import { StatusList } from '@app/components/transactions/components/StatusList/StatusList.tsx';
 import { getListEntries } from '@app/components/transactions/history/details/getListEntries.ts';
 import { useCallback, useRef, useState } from 'react';
+import { UserTransactionDTO } from '@tari-project/wxtm-bridge-backend-api';
 
 interface TransactionDetailsProps {
-    item: TransactionInfo;
+    item: TransactionInfo | UserTransactionDTO;
     expanded: boolean;
     handleClose: () => void;
 }

--- a/src/components/transactions/history/details/getListEntries.ts
+++ b/src/components/transactions/history/details/getListEntries.ts
@@ -1,20 +1,29 @@
 import i18n from 'i18next';
 import { TransactionInfo } from '@app/types/app-status.ts';
-import { formatTimeStamp } from '@app/components/transactions/history/helpers.ts';
+import { formatTimeStamp, isTransactionInfo } from '@app/components/transactions/history/helpers.ts';
 import { ReactNode } from 'react';
 import { formatNumber, FormatPreset } from '@app/utils';
 import { StatusListEntry } from '@app/components/transactions/components/StatusList/StatusList.tsx';
 import { Network } from '@app/utils/network.ts';
 import { useMiningStore } from '@app/store';
 import { getTxStatusTitleKey, getTxTitle } from '@app/utils/getTxStatus.ts';
+import { UserTransactionDTO } from '@tari-project/wxtm-bridge-backend-api';
 
-type Key = keyof TransactionInfo;
-type Entry = {
+type TransactionKey = keyof TransactionInfo;
+type TransactionEntry = {
     [K in keyof TransactionInfo]-?: {
         key: K;
         value: TransactionInfo[K];
     };
 }[keyof TransactionInfo];
+
+type BridgeTransactionKey = keyof UserTransactionDTO;
+type BridgeTransactionEntry = {
+    [K in keyof UserTransactionDTO]-?: {
+        key: K;
+        value: UserTransactionDTO[K];
+    };
+}[keyof UserTransactionDTO];
 
 const network = useMiningStore.getState().network;
 const explorerURL = `https://${network === Network.Esmeralda ? 'textexplore-esmeralda' : network === Network.NextNet ? 'explore-nextnet' : 'explore'}.tari.com`;
@@ -35,11 +44,13 @@ function getLabel(key: string): string {
     return key in keyTranslations ? i18n.t(keyTranslations[key]) : capitalizeKey(key);
 }
 
-function parseValues({
+function parseTransactionValues({
     key,
     value,
     transaction,
-}: Entry & { transaction: TransactionInfo }): Partial<StatusListEntry> & { value: ReactNode } {
+}: TransactionEntry & { transaction: TransactionInfo }): Partial<StatusListEntry> & {
+    value: ReactNode;
+} {
     const rest: Partial<StatusListEntry> = {};
     if (key === 'timestamp') {
         return { value: formatTimeStamp(value) };
@@ -58,6 +69,7 @@ function parseValues({
             valueRight: `${formatNumber(value, FormatPreset.DECIMAL_COMPACT)} µT`,
         };
     }
+
     if (key === 'mined_in_block_height' && value) {
         rest['externalLink'] = `${explorerURL}/blocks/${value}`;
     }
@@ -65,14 +77,77 @@ function parseValues({
     return { value, ...rest };
 }
 
-export function getListEntries(item: TransactionInfo, showHidden = false) {
+function parseBridgeTransactionValues({
+    key,
+    value,
+    transaction,
+}: BridgeTransactionEntry & { transaction: UserTransactionDTO }): Partial<StatusListEntry> & {
+    value: ReactNode;
+} {
+    const rest: Partial<StatusListEntry> = {};
+    if (key === 'status') {
+        const tKey = getTxStatusTitleKey(transaction);
+        return { value: i18n.t(`common:${tKey}`), valueRight: value };
+    }
+    if (key === 'tokenAmount') {
+        const preset = value.toString().length > 5 ? FormatPreset.XTM_LONG : FormatPreset.XTM_DECIMALS;
+        return {
+            value: formatNumber(Number(value), preset),
+            valueRight: `${formatNumber(Number(value), FormatPreset.DECIMAL_COMPACT)} µT`,
+        };
+    }
+    if (key === 'amountAfterFee') {
+        const preset = value.toString().length > 5 ? FormatPreset.XTM_LONG : FormatPreset.XTM_DECIMALS;
+        return {
+            value: formatNumber(Number(value), preset),
+            valueRight: `${formatNumber(Number(value), FormatPreset.DECIMAL_COMPACT)} µT`,
+        };
+    }
+    if (key === 'feeAmount') {
+        const preset = value.toString().length > 5 ? FormatPreset.XTM_LONG : FormatPreset.XTM_DECIMALS;
+        return {
+            value: formatNumber(Number(value), preset),
+            valueRight: `${formatNumber(Number(value), FormatPreset.DECIMAL_COMPACT)} µT`,
+        };
+    }
+
+    if (key === 'destinationAddress') {
+        return { label: 'Destination address [ ETH ]', value: transaction.destinationAddress };
+    }
+
+    return { value, ...rest };
+}
+
+export function getListEntries(item: TransactionInfo | UserTransactionDTO, showHidden = false) {
     const entries = Object.entries(item).filter(([key]) => showHidden || !HIDDEN_KEYS.includes(key));
     return entries.map(([key, _value]) => {
-        const { value, ...rest } = parseValues({ key: key as Key, value: _value, transaction: item });
-        return {
-            label: getLabel(key),
-            value,
-            ...rest,
-        };
+        // const { value, ...rest } = parseTransactionValues({
+        //     key: key as TransactionKey,
+        //     value: _value,
+        //     transaction: item,
+        // });
+        if (isTransactionInfo(item)) {
+            const { value, ...rest } = parseTransactionValues({
+                key: key as TransactionKey,
+                value: _value,
+                transaction: item,
+            });
+            return {
+                label: getLabel(key),
+                value,
+                ...rest,
+            };
+        } else {
+            const { value, ...rest } = parseBridgeTransactionValues({
+                key: key as BridgeTransactionKey,
+                value: _value,
+                transaction: item,
+            });
+            return {
+                label: getLabel(key),
+                value,
+                ...rest,
+            };
+        }
     });
 }

--- a/src/components/transactions/history/helpers.ts
+++ b/src/components/transactions/history/helpers.ts
@@ -1,4 +1,6 @@
 import { useConfigUIStore } from '@app/store';
+import { TransactionInfo } from '@app/types/app-status';
+import { UserTransactionDTO } from '@tari-project/wxtm-bridge-backend-api';
 
 function formatTimeStamp(timestamp: number): string {
     const appLanguage = useConfigUIStore.getState().application_language;
@@ -11,4 +13,51 @@ function formatTimeStamp(timestamp: number): string {
         minute: 'numeric',
     });
 }
-export { formatTimeStamp };
+
+function formatBridgeDateToTimestamp(date: string): number {
+    //2025-05-28T08:53:02.859Z
+    const dateObj = new Date(date);
+    if (isNaN(dateObj.getTime())) {
+        throw new Error('Invalid date format');
+    }
+    return Math.floor(dateObj.getTime() / 1000); // Convert to seconds
+}
+
+function getTimestampFromTransaction(transaction: TransactionInfo | UserTransactionDTO): number {
+    if (isTransactionInfo(transaction)) {
+        return transaction.timestamp;
+    } else if (isBridgeTransaction(transaction)) {
+        return formatBridgeDateToTimestamp(transaction.createdAt);
+    }
+    throw new Error('Invalid transaction type');
+}
+
+function findFirstNonBridgeTransaction(
+    transactions: (TransactionInfo | UserTransactionDTO)[]
+): TransactionInfo | undefined {
+    return transactions.find((tx) => 'direction' in tx && tx.direction !== undefined) as TransactionInfo | undefined;
+}
+
+function findByTransactionId(
+    transactions: (TransactionInfo | UserTransactionDTO)[],
+    txId: number | undefined
+): TransactionInfo | undefined {
+    return transactions.find((tx) => 'tx_id' in tx && tx.tx_id === txId) as TransactionInfo | undefined;
+}
+
+function isBridgeTransaction(transaction: TransactionInfo | UserTransactionDTO): transaction is UserTransactionDTO {
+    return 'tokenAmount' in transaction && typeof transaction.tokenAmount === 'string';
+}
+
+function isTransactionInfo(transaction: TransactionInfo | UserTransactionDTO): transaction is TransactionInfo {
+    return 'tx_id' in transaction && typeof transaction.tx_id === 'number';
+}
+
+export {
+    formatTimeStamp,
+    findFirstNonBridgeTransaction,
+    findByTransactionId,
+    isBridgeTransaction,
+    isTransactionInfo,
+    getTimestampFromTransaction,
+};

--- a/src/components/transactions/types.ts
+++ b/src/components/transactions/types.ts
@@ -1,5 +1,6 @@
 import { TransactionInfo } from '@app/types/app-status.ts';
 import { TransactionDirection } from '@app/types/transactions.ts';
+import { UserTransactionDTO } from '@tari-project/wxtm-bridge-backend-api';
 
 export type TransationType = 'mined' | 'sent' | 'received' | 'unknown';
 
@@ -10,6 +11,13 @@ export interface HistoryListItemProps {
     setDetailsItem?: (item: TransactionInfo | null) => void;
 }
 
+export interface BridgeHistoryListItemProps {
+    item: UserTransactionDTO;
+    index: number;
+    itemIsNew?: boolean;
+    setDetailsItem?: (item: UserTransactionDTO | null) => void;
+}
+
 export interface BaseItemProps {
     title: string;
     direction: TransactionDirection;
@@ -17,5 +25,14 @@ export interface BaseItemProps {
     value: string;
     chip?: string;
     status?: number;
+    onClick?: () => void;
+}
+
+export interface BridgeBaseItemProps {
+    title: string;
+    time: string;
+    value: string;
+    chip?: string;
+    status?: UserTransactionDTO.status;
     onClick?: () => void;
 }

--- a/src/store/actions/appConfigStoreActions.ts
+++ b/src/store/actions/appConfigStoreActions.ts
@@ -325,6 +325,7 @@ export const fetchBackendInMemoryConfig = async () => {
     try {
         const res = await invoke('get_app_in_memory_config');
         if (res) {
+            console.log('Fetched backend in memory config:', res);
             useConfigBEInMemoryStore.setState({ ...res });
         }
     } catch (e) {

--- a/src/store/actions/setupStoreActions.ts
+++ b/src/store/actions/setupStoreActions.ts
@@ -18,9 +18,14 @@ import { ProgressTrackerUpdatePayload } from '@app/hooks/app/useProgressEventsLi
 import { WalletAddress } from '@app/types/app-status.ts';
 import { setSeedlessUI } from '@app/store/actions/uiStoreActions.ts';
 import { fetchExchangeContent, useExchangeStore } from '@app/store/useExchangeStore.ts';
+import { fetchBridgeTransactionsHistory } from './walletStoreActions';
 
 export const handleAppUnlocked = async () => {
     useSetupStore.setState({ appUnlocked: true });
+    await fetchBridgeTransactionsHistory().catch((error) => {
+        console.error('Could not fetch bridge transactions history:', error);
+    });
+
     const visual_mode = useConfigUIStore.getState().visual_mode;
     const offset = useUIStore.getState().towerSidebarOffset;
     if (visual_mode) {

--- a/src/store/actions/walletStoreActions.ts
+++ b/src/store/actions/walletStoreActions.ts
@@ -6,6 +6,7 @@ import { restartMining } from './miningStoreActions';
 import { setError } from './appStateStoreActions';
 import { setExchangeContent } from '@app/store/useExchangeStore.ts';
 import { WrapTokenService, OpenAPI } from '@tari-project/wxtm-bridge-backend-api';
+import { useConfigBEInMemoryStore } from '../useAppConfigStore';
 interface TxArgs {
     continuation: boolean;
     limit?: number;
@@ -40,10 +41,8 @@ export const fetchTransactionsHistory = async ({ continuation, limit }: TxArgs) 
 
 export const fetchBridgeTransactionsHistory = async () => {
     try {
-        OpenAPI.BASE = 'https://api.staging-bridge.tari.com';
-        WrapTokenService.getUserTransactions(
-            'f2H4tt1WHihgmfsNki5eq7r2iRWE8Rs1ozXEN5HwqV8grF7YzSWJZdBuj4niw8ybxhdx1Jradin6QW2oU2NMoZnoQN7'
-        ).then((response) => {
+        OpenAPI.BASE = useConfigBEInMemoryStore.getState().nextPublicBackendApiUrl;
+        WrapTokenService.getUserTransactions(useWalletStore.getState().tari_address_base58).then((response) => {
             console.log('Bridge transactions fetched successfully:', response);
             useWalletStore.setState({
                 bridge_transactions: response.transactions,

--- a/src/store/actions/walletStoreActions.ts
+++ b/src/store/actions/walletStoreActions.ts
@@ -5,7 +5,7 @@ import { useWalletStore } from '../useWalletStore';
 import { restartMining } from './miningStoreActions';
 import { setError } from './appStateStoreActions';
 import { setExchangeContent } from '@app/store/useExchangeStore.ts';
-
+import { WrapTokenService, OpenAPI } from '@tari-project/wxtm-bridge-backend-api';
 interface TxArgs {
     continuation: boolean;
     limit?: number;
@@ -37,6 +37,23 @@ export const fetchTransactionsHistory = async ({ continuation, limit }: TxArgs) 
         useWalletStore.setState({ is_transactions_history_loading: false });
     }
 };
+
+export const fetchBridgeTransactionsHistory = async () => {
+    try {
+        OpenAPI.BASE = 'https://api.staging-bridge.tari.com';
+        WrapTokenService.getUserTransactions(
+            'f2H4tt1WHihgmfsNki5eq7r2iRWE8Rs1ozXEN5HwqV8grF7YzSWJZdBuj4niw8ybxhdx1Jradin6QW2oU2NMoZnoQN7'
+        ).then((response) => {
+            console.log('Bridge transactions fetched successfully:', response);
+            useWalletStore.setState({
+                bridge_transactions: response.transactions,
+            });
+        });
+    } catch (error) {
+        console.error('Could not get bridge transaction history: ', error);
+    }
+};
+
 export const importSeedWords = async (seedWords: string[]) => {
     try {
         useWalletStore.setState({ is_wallet_importing: true });

--- a/src/store/useAppConfigStore.ts
+++ b/src/store/useAppConfigStore.ts
@@ -69,6 +69,7 @@ const configBEInMemoryInitialState: ConfigBackendInMemory = {
     airdropApiUrl: '',
     airdropTwitterAuthUrl: '',
     exchangeId: undefined,
+    nextPublicBackendApiUrl: '',
 };
 
 export const useConfigCoreStore = create<ConfigCore>()(() => ({

--- a/src/store/useBlockchainVisualisationStore.ts
+++ b/src/store/useBlockchainVisualisationStore.ts
@@ -11,6 +11,7 @@ import { TransactionInfo, WalletBalance } from '@app/types/app-status.ts';
 import { setMiningControlsEnabled } from './actions/miningStoreActions.ts';
 import { refreshPendingTransactions, updateWalletScanningProgress, useWalletStore } from './useWalletStore.ts';
 import { useConfigUIStore } from '@app/store/useAppConfigStore.ts';
+import { fetchBridgeTransactionsHistory } from './actions/walletStoreActions.ts';
 
 const appWindow = getCurrentWindow();
 
@@ -173,6 +174,9 @@ export const handleNewBlock = async (payload: {
     coinbase_transaction?: TransactionInfo;
     balance: WalletBalance;
 }) => {
+    await fetchBridgeTransactionsHistory().catch((error) => {
+        console.error('Could not fetch bridge transactions history:', error);
+    });
     latestBlockPayload = payload;
 
     const isWalletScanned = !useWalletStore.getState().wallet_scanning?.is_scanning;

--- a/src/store/useWalletStore.ts
+++ b/src/store/useWalletStore.ts
@@ -1,6 +1,7 @@
 import { create } from './create';
 import { TransactionInfo, WalletBalance } from '../types/app-status.ts';
 import { refreshTransactions, setWalletBalance } from './actions/walletStoreActions.ts';
+import { GetUserTransactionsRespDTO, UserTransactionDTO } from '@tari-project/wxtm-bridge-backend-api';
 
 interface PendingTransaction {
     tx_id: number;
@@ -20,6 +21,8 @@ interface WalletStoreState {
     calculated_balance?: number;
     coinbase_transactions: TransactionInfo[];
     transactions: TransactionInfo[];
+    // TODO: decide later for the best place to store this data
+    bridge_transactions: UserTransactionDTO[];
     pending_transactions: PendingTransaction[];
     is_reward_history_loading: boolean;
     has_more_coinbase_transactions: boolean;
@@ -41,6 +44,7 @@ const initialState: WalletStoreState = {
     is_tari_address_generated: null,
     coinbase_transactions: [],
     transactions: [],
+    bridge_transactions: [],
     pending_transactions: [],
     has_more_coinbase_transactions: true,
     has_more_transactions: true,

--- a/src/types/configs.ts
+++ b/src/types/configs.ts
@@ -67,4 +67,5 @@ export interface ConfigBackendInMemory {
     airdropApiUrl: string;
     airdropTwitterAuthUrl: string;
     exchangeId?: string;
+    nextPublicBackendApiUrl: string;
 }

--- a/src/utils/getTxStatus.ts
+++ b/src/utils/getTxStatus.ts
@@ -6,6 +6,7 @@ import { TransactionInfo } from '@app/types/app-status.ts';
 import { UserTransactionDTO } from '@tari-project/wxtm-bridge-backend-api';
 import { useWalletStore } from '@app/store';
 import { formatNumber, FormatPreset } from './formatters';
+import { isTransactionInfo } from '@app/components/transactions/history/helpers';
 
 const txTypes = {
     oneSided: [
@@ -47,12 +48,16 @@ export function getTxTypeByStatus(transaction: TransactionInfo): TransationType 
     return 'unknown';
 }
 
-export function getTxStatusTitleKey(transaction: TransactionInfo): string | undefined {
-    return Object.keys(txStates).find((key) => {
-        if (txStates[key].includes(transaction.status)) {
-            return key;
-        }
-    });
+export function getTxStatusTitleKey(transaction: TransactionInfo | UserTransactionDTO): string | undefined {
+    if (isTransactionInfo(transaction)) {
+        return Object.keys(txStates).find((key) => {
+            if (txStates[key].includes(transaction.status)) {
+                return key;
+            }
+        });
+    } else {
+        return transaction.status === UserTransactionDTO.status.SUCCESS ? 'complete' : 'pending';
+    }
 }
 export function getTxTitle(transaction: TransactionInfo): string {
     const itemType = getTxTypeByStatus(transaction);
@@ -77,26 +82,4 @@ export function getTxTitle(transaction: TransactionInfo): string {
         return `${typeTitle} | ${statusTitle}`;
     }
     return i18n.t(`common:${itemType}`);
-}
-
-export function convertBridgeTransactionsToTransactions(bridgeTransactions: UserTransactionDTO[]): TransactionInfo[] {
-    const sourceAddress = useWalletStore.getState().tari_address_base58;
-    return bridgeTransactions.map((transaction, index) => ({
-        tx_id: index,
-        amount: Number(transaction.feeAmount),
-        mined_in_block_height: 0,
-        direction: 0,
-        status:
-            transaction.status === UserTransactionDTO.status.SUCCESS
-                ? TransactionStatus.Completed
-                : TransactionStatus.Pending,
-        timestamp: 0,
-        source_address: sourceAddress,
-        dest_address: transaction.destinationAddress,
-        payment_id: '',
-        fee: Number(transaction.feeAmount),
-        excess_sig: '',
-        is_cancelled: false,
-        message: '',
-    }));
 }

--- a/src/utils/getTxStatus.ts
+++ b/src/utils/getTxStatus.ts
@@ -3,6 +3,9 @@ import i18n from 'i18next';
 import { TransactionDirection, TransactionStatus } from '@app/types/transactions.ts';
 import { TransationType } from '@app/components/transactions/types.ts';
 import { TransactionInfo } from '@app/types/app-status.ts';
+import { UserTransactionDTO } from '@tari-project/wxtm-bridge-backend-api';
+import { useWalletStore } from '@app/store';
+import { formatNumber, FormatPreset } from './formatters';
 
 const txTypes = {
     oneSided: [
@@ -74,4 +77,26 @@ export function getTxTitle(transaction: TransactionInfo): string {
         return `${typeTitle} | ${statusTitle}`;
     }
     return i18n.t(`common:${itemType}`);
+}
+
+export function convertBridgeTransactionsToTransactions(bridgeTransactions: UserTransactionDTO[]): TransactionInfo[] {
+    const sourceAddress = useWalletStore.getState().tari_address_base58;
+    return bridgeTransactions.map((transaction, index) => ({
+        tx_id: index,
+        amount: Number(transaction.feeAmount),
+        mined_in_block_height: 0,
+        direction: 0,
+        status:
+            transaction.status === UserTransactionDTO.status.SUCCESS
+                ? TransactionStatus.Completed
+                : TransactionStatus.Pending,
+        timestamp: 0,
+        source_address: sourceAddress,
+        dest_address: transaction.destinationAddress,
+        payment_id: '',
+        fee: Number(transaction.feeAmount),
+        excess_sig: '',
+        is_cancelled: false,
+        message: '',
+    }));
 }


### PR DESCRIPTION
### [ Summary ]
- Added fetching of bridge transactions to universe app
- Bridge transactions are fetched on new block and app unlocked events
- Added new history list items to represent bridge transactions data

### [ Testing ]
Run in terminal: `NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID=89085ba8291ae91cf7e35f57ad60033d NEXT_PUBLIC_BACKEND_API_URL=https://api.staging-bridge.tari.com npm run tauri dev`